### PR TITLE
fix: use package name according to the framework param

### DIFF
--- a/site/src/app/docs/[framework]/configuration/page.mdx
+++ b/site/src/app/docs/[framework]/configuration/page.mdx
@@ -10,11 +10,13 @@ can extend or replace these with your own custom hooks as needed.
 To start, let's review the default configuration presented in the
 [Getting started](./getting-started) guide:
 
-```typescript
-import { createHooks, recommended } from "@css-hooks/react";
+<Pre>
+  <Code className="language-typescript">
+    {`import { createHooks, recommended } from "@css-hooks/${props.params.framework}";
 
-const [css, hooks] = createHooks(recommended);
-```
+    const [css, hooks] = createHooks(recommended);`}
+  </Code>
+</Pre>
 
 If you aren't interested in the recommended hooks, you can simply replace them
 with your own hooks:


### PR DESCRIPTION
I noticed that the first snippet of the [configuration page](https://css-hooks.com/docs/react/configuration) had the package name hardcoded. Since I assumed it should change according to the selected framework, I made it dynamic.

Unfortunately, I couldn't check this change locally, as I described on the following issue: https://github.com/css-hooks/css-hooks/issues/17
