### PR TITLE
feat: add get started button to hero section

### DIFF
--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -143,12 +143,7 @@ export default async function Home() {
                     <Link
                       href="/docs/react/getting-started"
                       className={className}
-                      style={hooks({
-                        ...style,
-                        desktop: {
-                          display: "none",
-                        },
-                      })}
+                      style={style}
                     >
                       <BookIcon aria-hidden="true" />
                       Docs
@@ -156,7 +151,7 @@ export default async function Home() {
                   )
                 }
               </CtaButton>
-              <CtaButton theme="purple">
+              <CtaButton theme="gray">
                 {({ className, style, ...restProps }) =>
                   exhausted(restProps) && (
                     <a
@@ -181,15 +176,15 @@ export default async function Home() {
                     <a
                       href="https://github.com/css-hooks/css-hooks"
                       className={className}
-                      style={style}
+                      style={hooks({
+                        ...style,
+                        desktop: {
+                          display: "none",
+                        },
+                      })}
                     >
                       <GitHubIcon aria-hidden="true" />
-                      <span>
-                        Star{" "}
-                        <span style={hooks({ mobile: { display: "none" } })}>
-                          on GitHub
-                        </span>
-                      </span>
+                      <span>Star</span>
                     </a>
                   )
                 }


### PR DESCRIPTION
As an user, I felt a bit strange about not having a direct link/button to the docs. Currently, on desktop, the user needs to scroll down to reach the React/Solid/Preact cards with the "Get started" button and finally be redirected to the docs.

Considering that, I'd suggest changing the buttons on the hero section a bit: the main button would redirect to the docs page and would always be rendered, regardless of the viewport resolution. While the secondary button could be the one to codesandbox on desktop and github on mobile. I think that codesandbox on mobile isn't as useful as on desktop, so that's why.

What do you think?

Preview

Desktop:
<img width="1552" alt="image" src="https://github.com/css-hooks/css-hooks/assets/8797405/86fb4632-dc67-4c35-856f-03e3edb9cf7f">

Mobile:
<img width="582" alt="image" src="https://github.com/css-hooks/css-hooks/assets/8797405/a582223c-2900-4d82-a036-539840d906f4">

