### PR TITLE
Declaration sorting & merge functionality

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -653,6 +653,80 @@ describe("css function", () => {
       },
     );
   });
+
+  describe("with noSort option", () => {
+    it("does not reorder properties", () => {
+      const createHooks = buildHooksSystem<{
+        background?: string;
+        color?: string;
+      }>();
+
+      const [, css] = createHooks(
+        {
+          foo: "&.foo",
+        },
+        { hookNameToId: x => x, noSort: true },
+      );
+
+      assert.deepStrictEqual(
+        css({
+          foo: { color: "red" },
+          color: "blue",
+        }),
+        {
+          color: "var(--foo-1, red) var(--foo-0, blue)",
+        },
+      );
+
+      {
+        const expected = {
+          background: "var(--foo-1, gray) var(--foo-0, black)",
+          color: "white",
+        };
+        const actual = css({
+          background: "black",
+          color: "white",
+          foo: { background: "gray" },
+        });
+        assert.deepStrictEqual(actual, expected);
+        assert.deepStrictEqual(Object.keys(actual), Object.keys(expected));
+      }
+    });
+
+    it("merges successive style objects without reordering properties", () => {
+      const createHooks = buildHooksSystem<{
+        background?: string;
+        backgroundColor?: string;
+      }>();
+
+      const [, css] = createHooks(
+        {
+          foo: "&.foo",
+        },
+        { hookNameToId: x => x, noSort: true },
+      );
+
+      const expected = {
+        backgroundColor: "var(--foo-1, blue) var(--foo-0, black)",
+        background: "orange",
+      };
+
+      const actual = css(
+        {
+          backgroundColor: "black",
+          background: "orange",
+        },
+        {
+          foo: {
+            backgroundColor: "blue",
+          },
+        },
+      );
+
+      assert.deepStrictEqual(actual, expected);
+      assert.deepStrictEqual(Object.keys(actual), Object.keys(expected));
+    });
+  });
 });
 
 describe("createHooks function", () => {


### PR DESCRIPTION
Following up on #43 primarily.

Although CSS Hooks makes a large amount of CSS functionality accessible to inline styles, there are a few limitations inherent to this approach compared to "real CSS". (If you read the [introduction](https://css-hooks.com/docs/react/introduction#top) to learn how hooks work "under the hood", these limitations are much easier to understand.) We don't have tools like specificity or shorthand/longhand composition, so there will always be a few awkward corner cases (usually with simple workarounds) around the ordering of declarations.

With that said, @jjenzz has highlighted an important issue where I think there's room for improvement:

> the expectation is usually that "the last style applied always wins".

Currently, the `css` function is not meeting this expectation. Nested style objects are "flattened" using simple property assignment, effectively moving each declaration/entry to the position where the property was set in the "parent" style object. That behavior is often surprising, especially for client code that doesn't have visibility into how its style overrides are applied.

With this change, each property would be moved to the end of the style object according to input order.

Consider this example:

```javascript
css({
  background: "blue",
  backgroundColor: "black",
  "&:hover": {
    background: "orange"
  }
})
```

Resulting style object _before_ this change:

```javascript
{
  background: "var(--hover-1, orange) var(--hover-0, blue)",
  backgroundColor: "black"
}
```

Notice how the `backgroundColor` declaration "wins" because it appears last, despite `background` being later in the input order.

Resulting style object _after_ this change:

```javascript
{
  backgroundColor: "black",
  background: "var(--hover-1, orange) var(--hover-0, blue)"
}
```

Now the `background` declaration would have the highest priority as expected.

In addition, the `css` function would now accept multiple style objects and merge them accordingly, so that the last declaration always overrides earlier declarations. While some community members have discussed more advanced merging strategies with me, I think this represents a "sensible default" (although if you're concerned about a specific use case, let's discuss!).

Because this involves a breaking change (albeit low-impact, I think?), I'd be grateful for any feedback/input you can offer. And if there aren't any objections, I'll coordinate this with some other minor changes I've been meaning to make and release v2 soon (in the next week or two perhaps).

Thanks for reviewing!

**Update**: I have a few "live" test cases [here](https://codesandbox.io/p/devbox/hungry-mcclintock-45fvp5?file=%2Fsrc%2FApp.tsx%3A2%2C1)