### PR TITLE
Performance Tweaks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -313,38 +313,35 @@ export function buildHooksSystem<Properties = Record<string, unknown>>(
           delete properties[hookName as unknown as keyof Properties];
         } else if (sort) {
           delete properties[key];
-          Object.assign(properties, { [key]: value });
+          properties[key as keyof Properties] =
+            value as (typeof properties)[keyof Properties];
         }
       }
       return properties as Properties;
     }
 
     function css(
-      ...properties: [
+      ...styles: [
         WithHooks<HookProperties, Properties>,
         ...(WithHooks<HookProperties, Properties> | undefined)[],
       ]
     ): Properties {
-      const styles = [{}].concat(
-        JSON.parse(JSON.stringify(properties)) as typeof properties,
-      ) as typeof properties;
       do {
         const current = styles[0];
         const next = styles[1] || ({} as WithHooks<HookProperties, Properties>);
-        if (options?.sort) {
-          for (const k in next) {
+        for (const k in next) {
+          if (options?.sort) {
             if (k in current) {
               delete current[k as keyof typeof current];
             }
+
+            styles[0][k as keyof Properties] = next[k as keyof Properties];
           }
         }
-        styles[0] = cssImpl(Object.assign(current, next)) as WithHooks<
-          HookProperties,
-          Properties
-        >;
+
         styles.splice(1, 1);
       } while (styles[1]);
-      return styles[0];
+      return cssImpl(styles[0]) as WithHooks<HookProperties, Properties>;
     }
 
     return [`*{${hooks.init}}${hooks.rule}`, css] as [string, typeof css];


### PR DESCRIPTION
While building [brandeur](https://github.com/robinweser/brandeur), I ran some performance tests and realised that **css-hooks@1.8.0 is ~35% slower than pure inline styles**. Given that inline styles are already around 40% slower than state-of-the-art runtime CSS-in-JS libraries, I wanted to give it a try and see if I can get any meaningful improvements out of it as I don't want to impact my app performance.
Eventually I noticed quite some immutability and arguably slow copying `JSON.parse(JSON.stringify(v))` which I don't think is necessary for this library as the input for `css` is usually recomputed and not reused.
Some tweaks later I managed to get it down to only ~15% overhead vs. pure inline styles, thus resulting in overall **20% faster renders**.

Would love to be proven otherwise, but I think my tweaks are fine and safe.
If we want to keep immutability, I can tweak the code once again maintaining at least 18% faster runs.