### PR TITLE
fix: re-export core types

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -7,6 +7,8 @@
 import { buildHooksSystem } from "@css-hooks/core";
 import type { JSX } from "preact";
 
+export type * from "@css-hooks/core";
+
 const IS_NON_DIMENSIONAL =
   /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
 

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -7,6 +7,8 @@
 import type { CSSProperties } from "@builder.io/qwik";
 import { buildHooksSystem } from "@css-hooks/core";
 
+export type * from "@css-hooks/core";
+
 /** @internal */
 export function _stringifyValue(value: unknown, propertyName: string) {
   switch (typeof value) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,8 @@
 import { buildHooksSystem } from "@css-hooks/core";
 import type { CSSProperties } from "react";
 
+export type * from "@css-hooks/core";
+
 // See https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/client/CSSPropertyOperations.js
 /** @internal */
 export function _stringifyValue(value: unknown, propertyName: string) {

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -7,6 +7,8 @@
 import { buildHooksSystem } from "@css-hooks/core";
 import type { JSX } from "solid-js";
 
+export type * from "@css-hooks/core";
+
 /**
  * A {@link @css-hooks/core#CreateHooksFn} configured to use Solid's
  * `JSX.CSSProperties` type and logic for converting CSS values into strings.


### PR DESCRIPTION
This change will re-export types from the core package to fix type resolution when using pnpm. This solution is based on https://github.com/microsoft/TypeScript/issues/42873#issuecomment-2040902002.