### PR TITLE
misc: handle already-set version in apply-version script

### DIFF
--- a/scripts/apply-version/main.ts
+++ b/scripts/apply-version/main.ts
@@ -21,10 +21,18 @@ async function main() {
 
   console.log(`🚀 Bumping all workspaces to: ${newVersion}`);
 
-  await exec(
-    `npm version ${newVersion} --no-git-tag-version --workspaces --include-workspace-root`,
-    { cwd: rootDirectory },
-  );
+  try {
+    await exec(
+      `npm version ${newVersion} --no-git-tag-version --workspaces --include-workspace-root`,
+      { cwd: rootDirectory },
+    );
+  } catch (e: unknown) {
+    const err = e as { stderr?: string };
+    if (!err.stderr?.includes("Version not changed")) {
+      throw e;
+    }
+    console.log("ℹ️  Version already set, skipping npm version bump.");
+  }
 
   const { stdout } = await exec("npm query .workspace", { cwd: rootDirectory });
   const workspaceData = parse(


### PR DESCRIPTION
## Summary

- Gracefully skips the `npm version` bump when packages are already at the target version, instead of failing with \"Version not changed\"
- This unblocks releases where a previous workflow run partially succeeded (committed the version bump) but failed before creating the GitHub release tag

## Root cause

The `misc: release v3.0.6-next.21` commit was made by the bot but the subsequent `softprops/action-gh-release` step failed with a 403, leaving the repo with bumped `package.json` files but no tag and no npm publish. All subsequent release workflow runs then failed immediately at `apply-version` because `npm version` exits non-zero when the version is unchanged.

## Test plan

- [ ] Merge into `next` — the release workflow should compute `3.0.6-next.21`, skip the version bump gracefully, and proceed to tag + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)