### PR TITLE
misc: pass token as input to softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,8 @@ jobs:
           committer_email: ${{ vars.RELEASE_BOT_APP_ID }}+CSS-Hooks-Release-Bot[bot]@users.noreply.github.com
 
       - uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
         with:
+          token: ${{ steps.app_token.outputs.token }}
           tag_name: v${{ steps.version.outputs.NEW_VERSION }}
           target_commitish: ${{ github.ref_name }}
           prerelease: ${{ github.ref_name == 'next' }}


### PR DESCRIPTION
## Summary

- Fixes 403 "Resource not accessible by integration" error when creating GitHub releases
- The `softprops/action-gh-release@v2` action was updated and stopped accepting the token via `env: GITHUB_TOKEN` — it must now be passed as `with: token:`

## Root cause

The `@v2` floating tag was updated between the v3.0.6-next.20 (success, SHA `a06a81a`) and v3.0.6-next.21 (failure, SHA `153bb8e`) release runs. The new version requires the token to be passed as an input rather than an environment variable override.

## Test plan

- [ ] Merge into `next` — the release workflow should successfully create the GitHub release tag and publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)