### PR TITLE
misc: update demo link to versioned tag in apply-version script

### DIFF
--- a/scripts/apply-version/main.ts
+++ b/scripts/apply-version/main.ts
@@ -85,6 +85,17 @@ async function main() {
 
   await Promise.all(patchPromises);
 
+  const homeTsxPath = resolve(rootDirectory, "site/src/routes/home.tsx");
+  const homeTsxContent = await readFile(homeTsxPath, "utf-8");
+  const updatedHomeTsx = homeTsxContent.replace(
+    /\bhttps:\/\/stackblitz\.com\/github\/css-hooks\/css-hooks\/tree\/[^/]+\/example\?file=src\/app\.tsx\b/g,
+    `https://stackblitz.com/github/css-hooks/css-hooks/tree/v${newVersion}/example?file=src/app.tsx`,
+  );
+  if (updatedHomeTsx !== homeTsxContent) {
+    await writeFile(homeTsxPath, updatedHomeTsx);
+    console.log(`✅ Updated StackBlitz link in: ${homeTsxPath}`);
+  }
+
   console.log("📦 Refreshing lockfile...");
   await exec("npm install --package-lock-only", { cwd: rootDirectory });
 


### PR DESCRIPTION
## Summary

- The apply-version script now updates the StackBlitz demo link in `site/src/routes/home.tsx` to point to the specific version tag (e.g. `v3.0.6`) instead of the `latest` branch.

## Test plan

- [ ] Run `apply-version` with a new version and verify `home.tsx` StackBlitz URL reflects the version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)