### PR TITLE
misc: add node types to script tsconfigs

### DIFF
--- a/scripts/apply-version/tsconfig.json
+++ b/scripts/apply-version/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "noEmit": true,
-    "customConditions": null
+    "customConditions": null,
+    "types": ["node"]
   },
   "include": ["main.ts"]
 }

--- a/scripts/calculate-version/tsconfig.json
+++ b/scripts/calculate-version/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "noEmit": true,
-    "customConditions": null
+    "customConditions": null,
+    "types": ["node"]
   },
   "include": ["main.ts"]
 }

--- a/scripts/readme/tsconfig.json
+++ b/scripts/readme/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "noEmit": true,
-    "customConditions": null
+    "customConditions": null,
+    "types": ["node"]
   },
   "include": ["main.ts"]
 }


### PR DESCRIPTION
## Summary

- Adds `"types": ["node"]` to the tsconfig for each script (`apply-version`, `calculate-version`, `readme`) to fix TypeScript errors about missing Node.js globals (e.g. `process`)

## Test plan

- [ ] Verify TypeScript errors no longer appear in `scripts/*/main.ts` in VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)