### PR TITLE
misc: update README badges and harden badge-replacement regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 <br/>
 
-<p align="center" id="badges">
-  <a href="https://github.com/css-hooks/css-hooks/tree/v3.0.6-next.21"><img src="https://img.shields.io/badge/tag-v3.0.6--next.21-hotpink" alt="tag v3.0.6-next.21"></a>
-  <a href="https://www.npmjs.com/package/@css-hooks/core/v/3.0.6-next.21"><img src="https://img.shields.io/badge/npm-v3.0.6--next.21-hotpink" alt="npm version"></a>
-  <a href="https://github.com/css-hooks/css-hooks/blob/v3.0.6-next.21/LICENSE"><img src="https://img.shields.io/badge/license-MIT-hotpink" alt="license"></a>
-</p>
+<div align="center" id="badges">
+  <a href="https://github.com/css-hooks/css-hooks/tree/v3.0.6-next.27"><img src="https://img.shields.io/badge/tag-v3.0.6--next.27-ffd700" alt="tag v3.0.6-next.27"></a>
+  <a href="https://www.npmjs.com/package/@css-hooks/core/v/3.0.6-next.27"><img src="https://img.shields.io/badge/npm-v3.0.6--next.27-ffd700" alt="npm version"></a>
+  <a href="https://github.com/css-hooks/css-hooks/blob/v3.0.6-next.27/LICENSE"><img src="https://img.shields.io/badge/license-MIT-ffd700" alt="license"></a>
+</div>
 
 ---
 

--- a/scripts/readme/main.ts
+++ b/scripts/readme/main.ts
@@ -95,10 +95,14 @@ async function main() {
           )
           .join("");
 
-        return readme.replace(
-          /<div[^>]+id="badges"[^>]*>([\S\s]*?)<\/div>/m,
+        const updated = readme.replace(
+          /<(\w+)[^>]+id="badges"[^>]*>([\S\s]*?)<\/\1>/m,
           `<div align="center" id="badges">${badges}\n</div>`,
         );
+        if (updated === readme) {
+          throw new Error("Could not find badges section in README.md");
+        }
+        return updated;
       },
       readme => readme.replace(/@css-hooks\/core/g, packageName),
     );


### PR DESCRIPTION
- Fix README badges tag from <p> to <div> (matching what the script writes) and update version to v3.0.6-next.27
- Make badge regex tag-agnostic via backreference so any element type matches, and throw an explicit error if no match is found