### PR TITLE
misc: ignore notarget error in apply-version when npm version bump succeeds

### DIFF
--- a/scripts/apply-version/main.ts
+++ b/scripts/apply-version/main.ts
@@ -28,7 +28,10 @@ async function main() {
     );
   } catch (e: unknown) {
     const err = e as { stderr?: string };
-    if (!err.stderr?.includes("Version not changed")) {
+    if (
+      !err.stderr?.includes("Version not changed") &&
+      !err.stderr?.includes("notarget")
+    ) {
       throw e;
     }
     console.log("ℹ️  Version already set, skipping npm version bump.");


### PR DESCRIPTION
## Summary

- The release workflow was failing because `npm version --workspaces` emits a `notarget` error when it can't resolve a workspace package's old pre-release version from the registry during its lockfile reconciliation step
- The version bumps actually succeed (all packages are updated as shown in stdout), so this error is safe to ignore — the lockfile is refreshed anyway by the subsequent `npm install --package-lock-only` call
- Extends the existing error-suppression pattern (which already ignores `"Version not changed"`) to also ignore `notarget` errors

## Test plan

- [ ] Trigger the release workflow and confirm `apply-version` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)