### PR TITLE
misc: fix false "badges section not found" error in readme --npm for @css-hooks/core

### DIFF
--- a/scripts/readme/main.ts
+++ b/scripts/readme/main.ts
@@ -95,14 +95,14 @@ async function main() {
           )
           .join("");
 
-        const updated = readme.replace(
-          /<(\w+)[^>]+id="badges"[^>]*>([\S\s]*?)<\/\1>/m,
-          `<div align="center" id="badges">${badges}\n</div>`,
-        );
-        if (updated === readme) {
+        const badgesRegex = /<(\w+)[^>]+id="badges"[^>]*>([\S\s]*?)<\/\1>/m;
+        if (!badgesRegex.test(readme)) {
           throw new Error("Could not find badges section in README.md");
         }
-        return updated;
+        return readme.replace(
+          badgesRegex,
+          `<div align="center" id="badges">${badges}\n</div>`,
+        );
       },
       readme => readme.replace(/@css-hooks\/core/g, packageName),
     );


### PR DESCRIPTION
## Summary

- The `--npm` step in the release workflow reads the root README and generates per-package READMEs
- For `@css-hooks/core` specifically, the root README already contains `@css-hooks/core` badges for the current version (written by the preceding `--ref` step without `--npm`)
- This means the badges replacement is a no-op — the generated content is identical to what's already there
- The previous fix used `if (updated === readme)` to detect a missing badges section, but this can't distinguish "regex didn't match" from "replacement was identical"
- Fix: test the regex explicitly first, then replace unconditionally

## Test plan

- [ ] Trigger the release workflow and confirm both the root README step and `--npm` step complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)