### PR TITLE
misc: use only lowercase characters in hashes

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -357,7 +357,7 @@ it("uses fixed-width hashes without known polynomial collisions", () => {
     return propertyName;
   });
 
-  assert(propertyNames.every(name => /^[A-Za-z0-9_-]{6}[01]$/.test(name)));
+  assert(propertyNames.every(name => /^[a-z0-9_-]{7}[01]$/.test(name)));
   assert.strictEqual(
     new Set(propertyNames.map(name => name.slice(0, -1))).size,
     2,
@@ -480,7 +480,10 @@ it('uses "revert-layer" in place of a fallback value that can\'t be stringified'
   );
   const { on } = createHooks("&:hover");
   const { width } = pipe({ width: 100 }, on("&:hover", { width: "200px" }));
-  assert.strictEqual(width, "var(--Lh11Md1,200px)var(--Lh11Md0,revert-layer)");
+  assert.match(
+    width,
+    /var\(--[a-z0-9_-]+1,200px\)var\(--[a-z0-9_-]+0,revert-layer\)/,
+  );
 });
 
 // type-level tests

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -352,8 +352,8 @@ export function buildHooksSystem<
   };
 }
 
-const hashAlphabet =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const hashAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789-_";
+const hashAlphabetLength = hashAlphabet.length;
 
 function createHash(value: string) {
   let h1 = 0xdeadbeef;
@@ -375,9 +375,9 @@ function createHash(value: string) {
   let hash = (h1 >>> 0) + 0x100000000 * (h2 & 0xf);
   let encoded = "";
 
-  for (let i = 0; i < 6; i++) {
-    encoded = hashAlphabet.charAt(hash % 64) + encoded;
-    hash = Math.floor(hash / 64);
+  for (let i = 0; i < 7; i++) {
+    encoded = hashAlphabet.charAt(hash % hashAlphabetLength) + encoded;
+    hash = Math.floor(hash / hashAlphabetLength);
   }
 
   return encoded;


### PR DESCRIPTION
Observed in desktop Safari that CSS variable names are normalized to lowercase, causing some hooks to break. Updated the createHash function to produce only lowercase hashes.