### PR TITLE
fix: handle optional property conflicts

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -564,3 +564,25 @@ it('uses "revert-layer" in place of a fallback value that can\'t be stringified'
 
   style satisfies { color: "blue"; textDecoration: "underline" };
 }
+
+// optional conflicts in a contextually inferred style
+{
+  type CSSProperties = {
+    background?: string;
+    backgroundAttachment?: string;
+    flexDirection?: "row" | "column";
+    minHeight?: string;
+  };
+
+  const createHooks = buildHooksSystem<
+    CSSProperties,
+    { background: "backgroundAttachment" }
+  >();
+  const { on } = createHooks("&");
+
+  pipe(
+    { flexDirection: "column" },
+    on("&", { minHeight: "100dvh" }),
+    on("&", { background: "black" }),
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,25 +67,7 @@ type CSSPropertyConflictKeys<
   keyof CSSPropertyConflicts] &
   PropertyKey;
 
-/**
- * Prevents conflicting CSS properties from being assigned values in a base
- * style.
- *
- * @typeParam CSSPropertyConflicts - A map from CSS properties to the properties
- *   with which they conflict
- * @typeParam OverrideCSSProperties - The conditional declarations for which
- *   conflicting properties are forbidden
- */
-type ForbidCSSPropertyConflicts<
-  CSSPropertyConflicts extends object,
-  OverrideCSSProperties,
-> = {
-  [
-    P in CSSPropertyConflictKeys<CSSPropertyConflicts, OverrideCSSProperties>
-  ]?: never;
-};
-
-/** Preserves a style's shape while replacing conflicting property values. */
+/** Preserves a style's shape while rejecting known-present conflicts. */
 type CSSPropertiesWithoutConflicts<
   CSSProperties,
   CSSPropertyConflicts extends object,
@@ -95,9 +77,11 @@ type CSSPropertiesWithoutConflicts<
     CSSPropertyConflicts,
     OverrideCSSProperties
   >
-    ? never
+    ? Pick<CSSProperties, P> extends Required<Pick<CSSProperties, P>>
+      ? never
+      : CSSProperties[P]
     : CSSProperties[P];
-} & ForbidCSSPropertyConflicts<CSSPropertyConflicts, OverrideCSSProperties>;
+};
 
 /**
  * An object containing the functions needed to support and use the configured


### PR DESCRIPTION
Only reject conflicting properties that are known to be present. This avoids false errors when contextual typing widens a style to a framework's CSS properties.