### PR TITLE
misc: type-check the site during build

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
   },
   "wireit": {
     "build": {
-      "command": "tsc && NODE_ENV=production react-router build",
+      "command": "tsc -b && NODE_ENV=production react-router build",
       "dependencies": [
         "../packages/react:build"
       ]

--- a/site/src/data/meta.ts
+++ b/site/src/data/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaDescriptors } from "react-router/route-module";
+import type { MetaDescriptor } from "react-router";
 
 const baseURL = "https://css-hooks.com";
 
@@ -17,7 +17,7 @@ export const createMetaDescriptors =
   <Args extends { location: { pathname: string } }>(
     argsIn:
       CreateMetaDescriptorArgs | ((args: Args) => CreateMetaDescriptorArgs),
-  ): ((args: Args) => MetaDescriptors) =>
+  ): ((args: Args) => MetaDescriptor[]) =>
   (args: Args) => {
     const defaultImage = "/opengraph.png";
     const {
@@ -27,7 +27,7 @@ export const createMetaDescriptors =
       title,
       description,
       image,
-    }: CreateMetaDescriptorArgs): MetaDescriptors => [
+    }: CreateMetaDescriptorArgs): MetaDescriptor[] => [
       { title: `${title ? `${title} — ` : ""}CSS Hooks` },
       { property: "og:title", content: title || "CSS Hooks" },
       { property: "og:image", content: url(image || defaultImage) },

--- a/site/src/routes/doc.tsx
+++ b/site/src/routes/doc.tsx
@@ -61,7 +61,9 @@ function MenuList({ children }: { children: ReactNode }) {
         {
           listStyleType: "none",
           margin: 0,
-          padding: 0,
+          paddingTop: 0,
+          paddingRight: 0,
+          paddingBottom: 0,
           paddingLeft: 0,
         },
         on(".group &.group", {

--- a/site/tsconfig.app.json
+++ b/site/tsconfig.app.json
@@ -6,7 +6,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node", "vite/client"],
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "rootDirs": [".", "./.react-router/types"]
   },
   "include": [

--- a/site/tsconfig.node.json
+++ b/site/tsconfig.node.json
@@ -2,13 +2,12 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"]
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vite/client"]
   },
   "include": [
     "src/data/docs.ts",
-    "build.ts",
     "global.d.ts",
     "react-router.config.ts",
     "vite.config.ts"


### PR DESCRIPTION
Run the TypeScript solution build (tsc -b) so the referenced app and node projects are actually checked, align their tsconfigs accordingly, and resolve the source errors that build-mode checking surfaces.