### PR TITLE
misc: keep webref css updates manual

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,11 @@
       "enabled": false
     },
     {
+      "description": "Keep CSS conflict generation data updates manual",
+      "matchPackageNames": ["@webref/css"],
+      "enabled": false
+    },
+    {
       "description": "Block typescript v7 without linting support",
       "matchPackageNames": ["typescript"],
       "allowedVersions": "/^[0-68-9]|7\\.[^0]/"


### PR DESCRIPTION
The `@webref/css` data generates published conflict maps, so dependency changes need deliberate review and regeneration rather than automated Renovate upgrades.