### PR TITLE
misc: test supported typescript versions

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -63,6 +63,27 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run build --workspaces --if-present
 
+  typescript:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [5, 7]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm install --no-save typescript@${{ matrix.version }}
+      - name: build
+        run: |
+          npx tsc --project packages/core/tsconfig.json --noEmit
+          npx tsc --project packages/preact/tsconfig.json --noEmit
+          npx tsc --project packages/qwik/tsconfig.json --noEmit
+          npx tsc --project packages/react/tsconfig.json --noEmit
+          npx tsc --project packages/solid/tsconfig.json --noEmit
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [5, 7]
+        version: [5.8, 7]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -50,4 +50,43 @@ describe("`stringifyValue` function", () => {
     on("&", { color: "blue" }),
     on("&", { textDecoration: "underline" }),
   ) satisfies CSSProperties;
+
+  // Keep long pipelines from recursively nesting conflict-validation types.
+  pipe(
+    { display: "inline-flex", alignItems: "center" },
+    on("&", { fontWeight: 500, color: "red" }),
+    on("&", { gap: 8, padding: 6, transitionProperty: "color" }),
+    on("&", { color: "blue" }),
+    on("&", {
+      justifyContent: "center",
+      fontSize: "1rem",
+      fontWeight: 600,
+      outline: "none",
+      borderRadius: 8,
+      boxShadow: "none",
+      transitionTimingFunction: "ease-in-out",
+      transitionDuration: "0.1s",
+      transitionProperty: "background-color",
+    }),
+    on("&", { boxShadow: "0 0 0 2px black" }),
+    on("&", { padding: 12, color: "black", backgroundColor: "transparent" }),
+    on("&", { color: "green" }),
+    on("&", {
+      gap: 6,
+      color: "gray",
+      backgroundColor: "white",
+      borderColor: "black",
+      borderStyle: "solid",
+      borderWidth: 1,
+    }),
+    on("&", { color: "white", backgroundColor: "black" }),
+    on("&", { opacity: 0.5 }),
+  ) satisfies CSSProperties;
+
+  // Repeated overrides should remain assignable after type widening.
+  pipe(
+    { animationDuration: "300ms" },
+    on("&", { animationName: "dialogOut" }),
+    on("&", { animationName: "dialogIn" }),
+  ) satisfies CSSProperties;
 }


### PR DESCRIPTION
Compile packages against manually installed TypeScript 5 and 7 in CI while keeping TypeScript 6 as the repository default, and cover long React pipelines with type-level regression tests.