### PR TITLE
fix: avoid excessive type instantiations

### DIFF
--- a/docs/api/core.createhooksresult.md
+++ b/docs/api/core.createhooksresult.md
@@ -83,7 +83,7 @@ Negates a condition.
 
 </td><td>
 
-&lt;OverrideCSSProperties extends CSSProperties, BaseCSSProperties extends CSSProperties&gt;(condition: [Condition](./core.condition.md)<!-- -->&lt;S&gt;, overrideStyle: OverrideCSSProperties) =&gt; (style: CSSProperties &amp; CSSPropertiesWithoutConflicts&lt;BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties&gt;) =&gt; Omit&lt;CSSPropertiesWithoutConflicts&lt;BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties&gt;, keyof OverrideCSSProperties&gt; &amp; OverrideCSSProperties
+&lt;OverrideCSSProperties extends CSSProperties, BaseCSSProperties extends CSSProperties&gt;(condition: [Condition](./core.condition.md)<!-- -->&lt;S&gt;, overrideStyle: OverrideCSSProperties) =&gt; (style: CSSProperties &amp; CSSPropertiesWithoutConflicts&lt;BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties&gt;) =&gt; Omit&lt;BaseCSSProperties, keyof OverrideCSSProperties&gt; &amp; OverrideCSSProperties
 
 
 </td><td>

--- a/docs/api/core.createhooksresult.on.md
+++ b/docs/api/core.createhooksresult.on.md
@@ -9,5 +9,5 @@ Creates a function that enhances a style object with conditional override styles
 **Signature:**
 
 ```typescript
-on: <OverrideCSSProperties extends CSSProperties, BaseCSSProperties extends CSSProperties>(condition: Condition<S>, overrideStyle: OverrideCSSProperties) => (style: CSSProperties & CSSPropertiesWithoutConflicts<BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties>) => Omit<CSSPropertiesWithoutConflicts<BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties>, keyof OverrideCSSProperties> & OverrideCSSProperties;
+on: <OverrideCSSProperties extends CSSProperties, BaseCSSProperties extends CSSProperties>(condition: Condition<S>, overrideStyle: OverrideCSSProperties) => (style: CSSProperties & CSSPropertiesWithoutConflicts<BaseCSSProperties, CSSPropertyConflicts, OverrideCSSProperties>) => Omit<BaseCSSProperties, keyof OverrideCSSProperties> & OverrideCSSProperties;
 ```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,14 +117,7 @@ export interface CreateHooksResult<
         CSSPropertyConflicts,
         OverrideCSSProperties
       >,
-  ) => Omit<
-    CSSPropertiesWithoutConflicts<
-      BaseCSSProperties,
-      CSSPropertyConflicts,
-      OverrideCSSProperties
-    >,
-    keyof OverrideCSSProperties
-  > &
+  ) => Omit<BaseCSSProperties, keyof OverrideCSSProperties> &
     OverrideCSSProperties;
 
   /**


### PR DESCRIPTION
Keep conflict validation on on() inputs while returning a lightweight merged result type, preventing recursive mapped types across pipelines.