### PR TITLE
misc: exclude CSS property conflict docs from site

### DIFF
--- a/site/src/data/docs.ts
+++ b/site/src/data/docs.ts
@@ -2,7 +2,10 @@ import fm from "front-matter";
 import * as v from "valibot";
 
 export const docs = Object.entries(
-  import.meta.glob("../../../docs/**/*.md", { eager: true, query: "raw" }),
+  import.meta.glob(
+    ["../../../docs/**/*.md", "!../../../docs/**/*.csspropertyconflicts.md"],
+    { eager: true, query: "raw" },
+  ),
 )
   .filter(
     (x): x is [string, { default: string }] =>

--- a/site/src/routes/doc.tsx
+++ b/site/src/routes/doc.tsx
@@ -324,6 +324,9 @@ export async function loader({ params }: Route.LoaderArgs) {
                 ? doc.attributes.pathname
                 : doc.attributes.pathname.replace(/\/[^/]+\/$/, "/"),
             );
+          if (to.endsWith(".csspropertyconflicts/")) {
+            return <>{children}</>;
+          }
           return (
             <AnchorLink
               href={to}


### PR DESCRIPTION
Avoid prerendering the generated CSSPropertyConflicts API pages and render their remaining API index references as plain text.