### PR TITLE
breaking: support solid v2

### DIFF
--- a/docs/quickstart/solid/index.md
+++ b/docs/quickstart/solid/index.md
@@ -29,7 +29,7 @@ export const { on, styleSheet } = createHooks("&:active");
 Render `styleSheet()` once at the application root. In `src/index.tsx`:
 
 ```tsx
-import { render } from "solid-js/web";
+import { render } from "@solidjs/web";
 
 import App from "./App";
 import { styleSheet } from "./css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,6 +3006,28 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@solidjs/signals": {
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@solidjs/signals/-/signals-2.0.0-rc.6.tgz",
+      "integrity": "sha512-lPqwZNLPq1Z9CBvgXkMvi1ZFr5OHUiFNz1X40+yehszDWEbJkneZx7BGKIe9eMT/AN1NSL+PMjOiMyZaqVB2xw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@solidjs/web": {
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@solidjs/web/-/web-2.0.0-rc.6.tgz",
+      "integrity": "sha512-JgQ2NCjygQpZizZrVjcwPqH3dhIZQZoMRGoGSC6+Tr622cvbuXthDC3pKdNMsjCKCVp19UbT0kkPX15FOdT0pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "seroval": "~1.5.4",
+        "seroval-plugins": "~1.5.4"
+      },
+      "peerDependencies": {
+        "solid-js": "^2.0.0-rc.6"
+      }
+    },
     "node_modules/@total-typescript/ts-reset": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
@@ -9496,9 +9518,9 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
-      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9506,9 +9528,9 @@
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
-      "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.6.tgz",
+      "integrity": "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9721,15 +9743,17 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
-      "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-2.0.0-rc.6.tgz",
+      "integrity": "sha512-Z/M8s9ypLBf+6Bl3AAb5upgkYCl73HkpM+UxdUJ5uFGctTwpOQVCM9Gpj3Mjbiaki270HHUfA3Z0Lyn4w+fDtg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
+        "@solidjs/signals": "^2.0.0-rc.6",
         "csstype": "^3.1.0",
-        "seroval": "~1.5.0",
-        "seroval-plugins": "~1.5.0"
+        "seroval": "~1.5.4",
+        "seroval-plugins": "~1.5.4"
       }
     },
     "node_modules/source-map": {
@@ -11050,11 +11074,11 @@
         "@css-hooks/core": "4.0.0-next.18"
       },
       "devDependencies": {
-        "remeda": "^2.45.0",
-        "solid-js": "^1.7.11"
+        "@solidjs/web": "^2.0.0-rc.6",
+        "remeda": "^2.45.0"
       },
       "peerDependencies": {
-        "solid-js": ">=1.0.0 <2.0.0"
+        "@solidjs/web": "^2.0.0-beta.0"
       }
     },
     "scripts/apply-version": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -7,8 +7,8 @@
     "@css-hooks/core": "4.0.0-next.18"
   },
   "devDependencies": {
-    "remeda": "^2.45.0",
-    "solid-js": "^1.7.11"
+    "@solidjs/web": "^2.0.0-rc.6",
+    "remeda": "^2.45.0"
   },
   "files": [
     "cjs",
@@ -21,7 +21,7 @@
   "main": "cjs",
   "module": "esm",
   "peerDependencies": {
-    "solid-js": ">=1.0.0 <2.0.0"
+    "@solidjs/web": "^2.0.0-beta.0"
   },
   "private": false,
   "repository": {

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -6,7 +6,7 @@
 
 import type { CreateHooksFn } from "@css-hooks/core";
 import { buildHooksSystem } from "@css-hooks/core";
-import type { JSX } from "solid-js";
+import type { JSX } from "@solidjs/web";
 
 import type { CSSPropertyConflicts } from "./css-property-conflicts.ts";
 


### PR DESCRIPTION
Replace the `solid-js` peer dependency with `@solidjs/web` and source `JSX.CSSProperties` from its renderer-owned types. Update the quickstart to use the new render import path.