### PR TITLE
breaking: support qwik v2

### DIFF
--- a/docs/quickstart/qwik/index.md
+++ b/docs/quickstart/qwik/index.md
@@ -29,7 +29,7 @@ export const { on, styleSheet } = createHooks("&:active");
 Render `styleSheet()` once at the application root. In `src/main.tsx`:
 
 ```tsx
-import { render } from "@builder.io/qwik";
+import { render } from "@qwik.dev/core";
 
 import { App } from "./app";
 import { styleSheet } from "./css";
@@ -48,7 +48,7 @@ render(
 Use the registered `&:active` hook in a component:
 
 ```tsx
-import { component$ } from "@builder.io/qwik";
+import { component$ } from "@qwik.dev/core";
 import { pipe } from "remeda";
 
 import { on } from "./css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -668,27 +668,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@builder.io/qwik": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-1.18.0.tgz",
-      "integrity": "sha512-+55/TEF2FCLVlA2oJ+jOUetc5ja7H2NM8kl1i1fIngeFJR1DbOeIy3dg9Na/hza5JvGM9hVW9479rppjt7rgYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "launch-editor": "^2.11.1",
-        "rollup": "^4.52.4"
-      },
-      "bin": {
-        "qwik": "qwik-cli.cjs"
-      },
-      "engines": {
-        "node": ">=16.8.0 <18.0.0 || >=18.11"
-      },
-      "peerDependencies": {
-        "vite": ">=5 <8"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "21.2.2",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.2.tgz",
@@ -2017,6 +1996,16 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@qwik.dev/optimizer": {
+      "version": "2.1.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/optimizer/-/optimizer-2.1.0-beta.8.tgz",
+      "integrity": "sha512-UlxnV+sARxYCV+nKxHVRQpyRTrVn2g+Q4yRkxrGd75hmZG9R2aFiDUgmXpynwa0WnPK2tAg1Lu3ws6Ss7ej68w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.3.0 || >=21.0.0"
+      }
+    },
     "node_modules/@react-router/dev": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-8.3.0.tgz",
@@ -2407,7 +2396,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.0",
@@ -2421,7 +2411,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.0",
@@ -2435,7 +2426,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.0",
@@ -2449,7 +2441,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.0",
@@ -2463,7 +2456,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.0",
@@ -2477,7 +2471,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.0",
@@ -2491,7 +2486,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.0",
@@ -2505,7 +2501,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.0",
@@ -2519,7 +2516,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.0",
@@ -2533,7 +2531,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.57.0",
@@ -2547,7 +2546,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.0",
@@ -2561,7 +2561,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.0",
@@ -2575,7 +2576,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.0",
@@ -2589,7 +2591,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.0",
@@ -2603,7 +2606,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.57.0",
@@ -2617,7 +2621,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.0",
@@ -2631,7 +2636,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.0",
@@ -2645,7 +2651,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.0",
@@ -2659,7 +2666,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.57.0",
@@ -2673,7 +2681,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.0",
@@ -2687,7 +2696,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.0",
@@ -2701,7 +2711,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.0",
@@ -2715,7 +2726,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.57.0",
@@ -2729,7 +2741,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.0",
@@ -2743,7 +2756,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -6935,14 +6949,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-      "integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/levn": {
@@ -7321,6 +7335,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -9352,6 +9376,7 @@
       "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9613,9 +9638,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11034,14 +11059,125 @@
         "@css-hooks/core": "4.0.0-next.19"
       },
       "devDependencies": {
-        "@builder.io/qwik": "^1.9.0",
+        "@qwik.dev/core": "^2.0.0-beta.30",
         "remeda": "^2.45.0"
       },
       "peerDependencies": {
-        "@builder.io/qwik": ">=1.2.0 <2"
+        "@qwik.dev/core": ">=2.0.0-beta.30 <3"
       },
       "peerDependenciesMeta": {
-        "@builder.io/qwik": {
+        "@qwik.dev/core": {
+          "optional": true
+        }
+      }
+    },
+    "packages/qwik/node_modules/@qwik.dev/core": {
+      "version": "2.0.0-beta.43",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/core/-/core-2.0.0-beta.43.tgz",
+      "integrity": "sha512-B/l74Cosp/t4F+pYeQO+sszd1YUn1lqSjE5nDg2C/2e7s0pYs9ofhU/WL3K2gfSGAlQxjxWle20lWWg0PZqeng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@qwik.dev/optimizer": "2.1.0-beta.8",
+        "csstype": "^3.2.3",
+        "launch-editor": "^2.14.1",
+        "magic-string": "0.30.21"
+      },
+      "bin": {
+        "qwik": "qwik-cli.mjs"
+      },
+      "engines": {
+        "node": "^20.3.0 || >=21.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "*",
+        "vite": ">=8 <9",
+        "vitest": ">=2 <5"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "packages/qwik/node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -7,7 +7,7 @@
     "@css-hooks/core": "4.0.0-next.19"
   },
   "devDependencies": {
-    "@builder.io/qwik": "^1.9.0",
+    "@qwik.dev/core": "^2.0.0-beta.30",
     "remeda": "^2.45.0"
   },
   "files": [
@@ -22,10 +22,10 @@
   "module": "esm",
   "type": "module",
   "peerDependencies": {
-    "@builder.io/qwik": ">=1.2.0 <2"
+    "@qwik.dev/core": ">=2.0.0-beta.30 <3"
   },
   "peerDependenciesMeta": {
-    "@builder.io/qwik": {
+    "@qwik.dev/core": {
       "optional": true
     }
   },

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -4,9 +4,9 @@
  * @packageDocumentation
  */
 
-import type { CSSProperties } from "@builder.io/qwik";
 import type { CreateHooksFn } from "@css-hooks/core";
 import { buildHooksSystem } from "@css-hooks/core";
+import type { CSSProperties } from "@qwik.dev/core";
 
 import type { CSSPropertyConflicts } from "./css-property-conflicts.ts";
 


### PR DESCRIPTION
Update Qwik integration to Qwik v2: peer dependency and dev dependency now target @qwik.dev/core (>=2.0.0-beta.30 <3) instead of @builder.io/qwik (>=1.2.0 <2).