### PR TITLE
misc: add filename headers to docs code blocks

### DIFF
--- a/docs/quickstart/preact/index.md
+++ b/docs/quickstart/preact/index.md
@@ -16,9 +16,11 @@ npm install @css-hooks/preact@next remeda
 
 ## 2. Define a hook
 
-Create `src/css.ts`:
+Create a module for styling utilities:
 
 ```typescript
+// src/css.ts
+
 import { createHooks } from "@css-hooks/preact";
 
 export const { on, styleSheet } = createHooks("&:active");
@@ -26,9 +28,11 @@ export const { on, styleSheet } = createHooks("&:active");
 
 ## 3. Render the generated stylesheet
 
-Render `styleSheet()` once at the application root. In `src/main.tsx`:
+Render `styleSheet()` once at the application root:
 
 ```tsx
+// src/main.tsx
+
 import { render } from "preact";
 
 import { App } from "./app";
@@ -48,6 +52,8 @@ render(
 Use the registered `&:active` hook in a component:
 
 ```tsx
+// src/app.tsx
+
 import { pipe } from "remeda";
 
 import { on } from "./css";

--- a/docs/quickstart/qwik/index.md
+++ b/docs/quickstart/qwik/index.md
@@ -23,9 +23,11 @@ npm uninstall @builder.io/qwik
 npm install @css-hooks/qwik@next @qwik.dev/core remeda
 ```
 
-Then update `vite.config.ts`:
+Then replace the Qwik 1 optimizer import:
 
 ```diff
+// vite.config.ts
+
 -import { qwikVite } from "@builder.io/qwik/optimizer";
 +import { qwikVite } from "@qwik.dev/core/optimizer";
  import { defineConfig } from "vite";
@@ -39,18 +41,22 @@ Then update `vite.config.ts`:
  });
 ```
 
-And change `jsxImportSource` in `tsconfig.app.json`:
+Point `jsxImportSource` at Qwik 2:
 
 ```diff
+// tsconfig.app.json
+
 -    "jsxImportSource": "@builder.io/qwik",
 +    "jsxImportSource": "@qwik.dev/core",
 ```
 
 ## 3. Define a hook
 
-Create `src/css.ts`:
+Create a module for styling utilities:
 
 ```typescript
+// src/css.ts
+
 import { createHooks } from "@css-hooks/qwik";
 
 export const { on, styleSheet } = createHooks("&:active");
@@ -58,9 +64,11 @@ export const { on, styleSheet } = createHooks("&:active");
 
 ## 4. Render the generated stylesheet
 
-Render `styleSheet()` once at the application root. In `src/main.tsx`:
+Render `styleSheet()` once at the application root:
 
 ```tsx
+// src/main.tsx
+
 import "@qwik.dev/core/qwikloader.js";
 
 import { render } from "@qwik.dev/core";
@@ -82,6 +90,8 @@ render(
 Use the registered `&:active` hook in a component:
 
 ```tsx
+// src/app.tsx
+
 import { component$ } from "@qwik.dev/core";
 import { pipe } from "remeda";
 

--- a/docs/quickstart/react/index.md
+++ b/docs/quickstart/react/index.md
@@ -16,9 +16,11 @@ npm install @css-hooks/react@next remeda
 
 ## 2. Define a hook
 
-Create `src/css.ts`:
+Create a module for styling utilities:
 
 ```typescript
+// src/css.ts
+
 import { createHooks } from "@css-hooks/react";
 
 export const { on, styleSheet } = createHooks("&:active");
@@ -26,9 +28,11 @@ export const { on, styleSheet } = createHooks("&:active");
 
 ## 3. Render the generated stylesheet
 
-Render `styleSheet()` once at the application root. In `src/main.tsx`:
+Render `styleSheet()` once at the application root:
 
 ```tsx
+// src/main.tsx
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -48,6 +52,8 @@ createRoot(document.getElementById("root")!).render(
 Use the registered `&:active` hook in a component:
 
 ```tsx
+// src/App.tsx
+
 import { pipe } from "remeda";
 
 import { on } from "./css";

--- a/docs/quickstart/solid/index.md
+++ b/docs/quickstart/solid/index.md
@@ -24,9 +24,11 @@ npm install solid-js@next @solidjs/web@next
 npm install -D @solidjs/vite-plugin
 ```
 
-Then replace the plugin in `vite.config.ts`:
+Then replace the Solid 1 Vite plugin:
 
 ```diff
+// vite.config.ts
+
  import { defineConfig } from "vite";
 -import solid from "vite-plugin-solid";
 +import solid from "@solidjs/vite-plugin";
@@ -36,9 +38,11 @@ Then replace the plugin in `vite.config.ts`:
  });
 ```
 
-And change `jsxImportSource` in `tsconfig.app.json`:
+Point `jsxImportSource` at Solid 2:
 
 ```diff
+// tsconfig.app.json
+
 -    "jsxImportSource": "solid-js",
 +    "jsxImportSource": "@solidjs/web",
 ```
@@ -51,9 +55,11 @@ npm install @css-hooks/solid@next remeda
 
 ## 4. Define a hook
 
-Create `src/css.ts`:
+Create a module for styling utilities:
 
 ```typescript
+// src/css.ts
+
 import { createHooks } from "@css-hooks/solid";
 
 export const { on, styleSheet } = createHooks("&:active");
@@ -61,9 +67,11 @@ export const { on, styleSheet } = createHooks("&:active");
 
 ## 5. Render the generated stylesheet
 
-Render `styleSheet()` once at the application root. In `src/index.tsx`:
+Render `styleSheet()` once at the application root:
 
 ```tsx
+// src/index.tsx
+
 import { render } from "@solidjs/web";
 
 import App from "./App";
@@ -85,6 +93,8 @@ render(
 Use the registered `&:active` hook in a component:
 
 ```tsx
+// src/App.tsx
+
 import { pipe } from "remeda";
 
 import { on } from "./css";

--- a/docs/quickstart/vanilla/index.md
+++ b/docs/quickstart/vanilla/index.md
@@ -16,9 +16,11 @@ npm install @css-hooks/core@next remeda
 
 ## 2. Define a hook
 
-Create `src/css.ts`:
+Create a module for styling utilities:
 
 ```typescript
+// src/css.ts
+
 import { buildHooksSystem } from "@css-hooks/core";
 
 const createHooks = buildHooksSystem();
@@ -28,9 +30,12 @@ export const { on, styleSheet } = createHooks("&:active");
 
 ## 3. Render the generated stylesheet
 
-Add the stylesheet to the document once, near the application entry point:
+Add the generated stylesheet to the document once near the application entry
+point:
 
 ```typescript
+// src/main.ts
+
 import { styleSheet } from "./css";
 
 const style = document.createElement("style");
@@ -40,11 +45,13 @@ document.head.append(style);
 
 ## 4. Apply an override style
 
-The core package returns a style object. Your renderer must convert that object
-to an inline style string. This minimal example only supports the string values
-used below; use a renderer-appropriate serializer in an application.
+The core package returns a style object, so convert it to an inline style string
+before applying it. This minimal example only supports the string values used
+below; use a renderer-appropriate serializer in an application.
 
 ```typescript
+// src/main.ts
+
 import { pipe } from "remeda";
 
 import { on } from "./css";

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -46,10 +46,10 @@ work.
 | [ts-functional-pipe](https://biggyspender.github.io/ts-functional-pipe/) | [`pipeInto`](https://biggyspender.github.io/ts-functional-pipe/modules.html#pipeInto)                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | No library                                                               | [`pipe`](https://www.typescriptlang.org/play?#code/C4TwDgpgBACglpAYgVwHYGNhwPaoDwCSqYywANFAPKknAB8UAvFABRzGkBcURtAlEwbVgtANwAocRAAeYbACdgUAGZpMOVFDAIIeAIJ0WANwCGAG2QRuevtYky5ilWqy4tO-RQBCh0xatQehTKqNzwSC4anlA+tjH2sgpKqhiumtqQ0V4UAMKG4lBQfpbWZAUqqACMYTooqVFBMXRlhSEATDUR9bh42VB5ZXE5CY7JkW4Zuo19ORQAIvmFxQFB5SHVsLXj+NPNa6gdm13qPTN7ragAzJ0QdSf4s1ALg9xzI0nO3ek6LOXL3GgANaobAAd1QLSgADoYSl7gBnazyeQmEB4YzmEpQVAQIwQeQCRgMIEg8F0cRxElgzQAb3K8ggwGQ8k0cLS8KhDIAJsh0BAWCwGfDkGZyBVCQwQoKIMLRVATPDsbj8XwKMs+BIAL7iIA) |
 
-## Create the hooks module
+## Create the styling module
 
-Create a module, commonly `src/css.ts`, that exports the hooks used throughout
-your application. Framework integrations export `createHooks` directly:
+Create a module that exports the hooks used throughout your application.
+Framework integrations export `createHooks` directly:
 
 ```typescript
 // src/css.ts

--- a/site/src/routes/doc.tsx
+++ b/site/src/routes/doc.tsx
@@ -238,6 +238,17 @@ function createHeading(level: 1 | 2 | 3 | 4 | 5 | 6, style: CSSProperties) {
   return component;
 }
 
+const filenameCommentPattern =
+  /^\/\/[ \t]+((?:[\w.-]+\/)*[\w.-]+\.(?:[cm]?[jt]sx?|css|html|json))[ \t]*(?:\r?\n(?:[ \t]*\r?\n)?|$)/;
+
+function extractFilename(code: string) {
+  const match = code.match(filenameCommentPattern);
+  return {
+    code: match ? code.substring(match[0].length) : code,
+    filename: match?.[1],
+  };
+}
+
 export async function loader({ params }: Route.LoaderArgs) {
   const pathname = `/docs/${params["*"]}`;
   const doc = docs.find(
@@ -486,13 +497,58 @@ export async function loader({ params }: Route.LoaderArgs) {
         code: props => {
           const { children, className, node: _node, ref, ...rest } = props;
           const match = /language-(\w+)/.exec(className || "");
-          return match?.[1] ? (
-            <div {...rest} ref={ref as Ref<HTMLDivElement> | undefined}>
-              <SyntaxHighlighter language={match?.[1]}>
-                {String(children).replace(/\n$/, "")}
-              </SyntaxHighlighter>
-            </div>
-          ) : (
+          if (match?.[1]) {
+            const { code, filename } = extractFilename(
+              String(children).replace(/\n$/, ""),
+            );
+            return (
+              <div
+                {...rest}
+                ref={ref as Ref<HTMLDivElement> | undefined}
+                style={
+                  filename
+                    ? {
+                        width: "max-content",
+                        minWidth: "calc(100% + 24px)",
+                      }
+                    : undefined
+                }
+              >
+                {filename ? (
+                  <div
+                    style={pipe(
+                      {
+                        marginBlockStart: -16,
+                        marginInlineStart: -24,
+                        marginBlockEnd: 16,
+                        borderBottomWidth: 1,
+                        borderBottomStyle: "solid",
+                        borderColor: gray(20),
+                        paddingBlock: 8,
+                        paddingInline: 24,
+                        background: gray(10),
+                        color: gray(60),
+                        fontFamily: monospace,
+                        fontSize: "0.875em",
+                        lineHeight: 1.5,
+                      },
+                      on(dark, {
+                        borderColor: gray(70),
+                        background: gray(80),
+                        color: gray(35),
+                      }),
+                    )}
+                  >
+                    {filename}
+                  </div>
+                ) : null}
+                <SyntaxHighlighter language={match[1]}>
+                  {code}
+                </SyntaxHighlighter>
+              </div>
+            );
+          }
+          return (
             <code
               {...rest}
               className={className}


### PR DESCRIPTION
Render leading filename comments as code-block headers and label file-oriented guide examples.