### PR TITLE
fix: restore css require support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
     "!**/*.test.*"
   ],
   "license": "MIT",
-  "main": "cjs",
-  "module": "esm",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "type": "module",
   "private": false,
   "repository": {
@@ -40,7 +40,7 @@
       ]
     },
     "build": {
-      "command": "tsc && tsc --project tsconfig.cjs.json"
+      "command": "tsc && tsc --project tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('cjs/package.json', JSON.stringify({type:'commonjs'}))\""
     },
     "prepublishOnly": {
       "dependencies": [

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -18,8 +18,8 @@
     "!**/*.test.*"
   ],
   "license": "MIT",
-  "main": "cjs",
-  "module": "esm",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "type": "module",
   "peerDependencies": {
     "preact": "^10.27.2 || ^11.0.0-0"
@@ -49,7 +49,7 @@
       ]
     },
     "build": {
-      "command": "tsc && tsc --project tsconfig.cjs.json",
+      "command": "tsc && tsc --project tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
       "dependencies": [
         "../core:build"
       ]

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -18,8 +18,8 @@
     "!**/*.test.*"
   ],
   "license": "MIT",
-  "main": "cjs",
-  "module": "esm",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "type": "module",
   "peerDependencies": {
     "@qwik.dev/core": ">=2.0.0-beta.30 <3"
@@ -49,7 +49,7 @@
       ]
     },
     "build": {
-      "command": "tsc && tsc --project tsconfig.cjs.json",
+      "command": "tsc && tsc --project tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
       "dependencies": [
         "../core:build"
       ]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,8 +18,8 @@
     "!**/*.test.*"
   ],
   "license": "MIT",
-  "main": "cjs",
-  "module": "esm",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "type": "module",
   "peerDependencies": {
     "@types/react": ">=16 <20"
@@ -49,7 +49,7 @@
       ]
     },
     "build": {
-      "command": "tsc && tsc --project tsconfig.cjs.json",
+      "command": "tsc && tsc --project tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
       "dependencies": [
         "../core:build"
       ]

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -18,8 +18,8 @@
     "!**/*.test.*"
   ],
   "license": "MIT",
-  "main": "cjs",
-  "module": "esm",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
   "peerDependencies": {
     "@solidjs/web": "^2.0.0-beta.0"
   },
@@ -43,7 +43,7 @@
       ]
     },
     "build": {
-      "command": "tsc && tsc --project tsconfig.cjs.json",
+      "command": "tsc && tsc --project tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
       "dependencies": [
         "../core:build"
       ]


### PR DESCRIPTION
Packages declare `"type": "module"` but expose CommonJS output via the `"require"` export condition using `.js` files, so Node treated those files as ESM and `require("@css-hooks/*")` returned an empty module or threw. Emit a nested `cjs/package.json` with `"type": "commonjs"` during each build, and point `main`/`module` at `./cjs/index.js` and `./esm/index.js`.