### PR TITLE
fix: add px to dimensional numeric values in preact integration

### DIFF
--- a/packages/preact/src/index.test.ts
+++ b/packages/preact/src/index.test.ts
@@ -12,16 +12,15 @@ describe("`stringifyValue` function", () => {
     });
   });
 
-  it("returns numbers as direct string equivalents", () => {
-    [
-      "lineHeight",
-      "flexGrow",
-      "zIndex",
-      "width",
-      "marginTop",
-      "fontSize",
-    ].forEach(propertyName => {
+  it("returns unitless numbers as direct string equivalents", () => {
+    ["lineHeight", "flexGrow", "zIndex"].forEach(propertyName => {
       assert.equal(stringifyValue(1.5, propertyName), "1.5");
+    });
+  });
+
+  it("returns non-unitless numbers as px values", () => {
+    ["width", "marginTop", "fontSize"].forEach(propertyName => {
+      assert.equal(stringifyValue(15.5, propertyName), "15.5px");
     });
   });
 });

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -14,6 +14,9 @@ export type * from "@css-hooks/core";
 export { mergeStyles } from "@css-hooks/core";
 export type { CSSPropertyConflicts } from "./css-property-conflicts.ts";
 
+const IS_NON_DIMENSIONAL =
+  /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
+
 /**
  * A {@link @css-hooks/core#CreateHooksFn} configured to use Preact's
  * `CSSProperties` type and logic for converting CSS values into strings
@@ -24,12 +27,12 @@ export const createHooks: CreateHooksFn<CSSProperties, CSSPropertyConflicts> =
   buildHooksSystem<CSSProperties, CSSPropertyConflicts>(_stringifyValue);
 
 /** @internal */
-export function _stringifyValue(value: unknown, _propertyName: string) {
+export function _stringifyValue(value: unknown, propertyName: string) {
   switch (typeof value) {
     case "string":
       return value;
     case "number":
-      return String(value);
+      return `${value}${IS_NON_DIMENSIONAL.test(propertyName) ? "" : "px"}`;
     default:
       return null;
   }


### PR DESCRIPTION
Preact v11's CSSProperties type allows numeric length values (e.g. `width: 50`), but they don't work at runtime. To avoid this issue, the Preact stringify function has been reverted to the v3 implementation.