### PR TITLE
fix: preserve numeric preact custom properties

### DIFF
--- a/packages/preact/src/index.test.ts
+++ b/packages/preact/src/index.test.ts
@@ -18,6 +18,10 @@ describe("`stringifyValue` function", () => {
     });
   });
 
+  it("assumes numbers assigned to custom properties are unitless values", () => {
+    assert.equal(stringifyValue(7, "--foo"), "7");
+  });
+
   it("returns non-unitless numbers as px values", () => {
     ["width", "marginTop", "fontSize"].forEach(propertyName => {
       assert.equal(stringifyValue(15.5, propertyName), "15.5px");

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -32,7 +32,7 @@ export function _stringifyValue(value: unknown, propertyName: string) {
     case "string":
       return value;
     case "number":
-      return `${value}${IS_NON_DIMENSIONAL.test(propertyName) ? "" : "px"}`;
+      return `${value}${propertyName.startsWith("--") || IS_NON_DIMENSIONAL.test(propertyName) ? "" : "px"}`;
     default:
       return null;
   }


### PR DESCRIPTION
## summary

- preserve numeric custom property values as unitless strings in the Preact serializer
- keep pixel conversion for dimensional standard properties
- add regression coverage for numeric custom properties

## verification

- npm test --workspace=@css-hooks/preact
- npm run build --workspace=@css-hooks/preact
- npx eslint packages/preact/src/index.ts packages/preact/src/index.test.ts --max-warnings=0
- npx prettier -c packages/preact/src/index.ts packages/preact/src/index.test.ts