### PR TITLE
fix: stringify kebab-case unitless qwik properties

### DIFF
--- a/packages/qwik/src/index.test.ts
+++ b/packages/qwik/src/index.test.ts
@@ -22,12 +22,24 @@ describe("`stringifyValue` function", () => {
     });
   });
 
+  it("recognizes kebab-case unitless properties", () => {
+    [
+      "animation-iteration-count",
+      "line-height",
+      "-moz-box-flex",
+      "-ms-flex",
+      "-webkit-line-clamp",
+    ].forEach(propertyName => {
+      assert.equal(stringifyValue(1.5, propertyName), "1.5");
+    });
+  });
+
   it("assumes numbers assigned to custom properties are unitless values", () => {
     assert.equal(stringifyValue(7, "--foo"), "7");
   });
 
   it("returns non-unitless numbers as px values", () => {
-    ["width", "marginTop", "fontSize"].forEach(propertyName => {
+    ["width", "marginTop", "margin-top", "fontSize"].forEach(propertyName => {
       assert.equal(stringifyValue(15.5, propertyName), "15.5px");
     });
   });

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -93,5 +93,11 @@ export const _unitlessNumbers = new Set([
 ]);
 
 function isUnitlessNumber(name: string) {
-  return /^--/.test(name) || _unitlessNumbers.has(name);
+  if (name.startsWith("--")) {
+    return true;
+  }
+  const camelCaseName = name
+    .replace(/^-ms-/, "ms-")
+    .replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+  return _unitlessNumbers.has(camelCaseName);
 }


### PR DESCRIPTION
## Summary
1. Normalize kebab-case Qwik property names before checking the unitless property set.
2. Handle `Moz`, `ms`, and `Webkit` vendor-prefixed names.
3. Add regression coverage for kebab-case unitless and dimensional properties.