### PR TITLE
misc: standardize framework version references

### DIFF
--- a/docs/quickstart/qwik/index.md
+++ b/docs/quickstart/qwik/index.md
@@ -13,17 +13,17 @@ npm create vite@latest css-hooks-playground -- --template qwik-ts
 cd css-hooks-playground
 ```
 
-## 2. Upgrade to Qwik 2
+## 2. Upgrade to Qwik v2
 
-The Vite `qwik-ts` template ships Qwik 1, which does not support Vite 8. Replace
-it with Qwik 2 and install CSS Hooks:
+The Vite `qwik-ts` template ships Qwik v1, which does not support Vite 8.
+Replace it with Qwik v2 and install CSS Hooks:
 
 ```bash
 npm uninstall @builder.io/qwik
 npm install @css-hooks/qwik@next @qwik.dev/core remeda
 ```
 
-Then replace the Qwik 1 optimizer import:
+Then replace the Qwik v1 optimizer import:
 
 ```diff
 // vite.config.ts
@@ -41,7 +41,7 @@ Then replace the Qwik 1 optimizer import:
  });
 ```
 
-Point `jsxImportSource` at Qwik 2:
+Point `jsxImportSource` at Qwik v2:
 
 ```diff
 // tsconfig.app.json

--- a/docs/quickstart/solid/index.md
+++ b/docs/quickstart/solid/index.md
@@ -13,10 +13,11 @@ npm create vite@latest css-hooks-playground -- --template solid-ts
 cd css-hooks-playground
 ```
 
-## 2. Upgrade to Solid 2
+## 2. Upgrade to Solid v2
 
-The Vite `solid-ts` template targets Solid 1, but `@css-hooks/solid` v4 targets
-Solid 2. Replace the Solid 1 plugin and packages with their Solid 2 equivalents:
+The Vite `solid-ts` template targets Solid v1, but `@css-hooks/solid` v4 targets
+Solid v2. Replace the Solid v1 plugin and packages with their Solid v2
+equivalents:
 
 ```bash
 npm uninstall vite-plugin-solid
@@ -24,7 +25,7 @@ npm install solid-js@next @solidjs/web@next
 npm install -D @solidjs/vite-plugin
 ```
 
-Then replace the Solid 1 Vite plugin:
+Then replace the Solid v1 Vite plugin:
 
 ```diff
 // vite.config.ts
@@ -38,7 +39,7 @@ Then replace the Solid 1 Vite plugin:
  });
 ```
 
-Point `jsxImportSource` at Solid 2:
+Point `jsxImportSource` at Solid v2:
 
 ```diff
 // tsconfig.app.json


### PR DESCRIPTION
## Summary

- use the `Framework vN` convention throughout the Solid and Qwik quickstarts
- retain package specifiers and code examples unchanged

## Validation

- `npx prettier -c "docs/**/*.md"`
- `npm run build -w site`
- `git diff --check`